### PR TITLE
feat: change the prefix to `~` & add TimestampAllTable option

### DIFF
--- a/go/base/context.go
+++ b/go/base/context.go
@@ -304,7 +304,7 @@ func (this *MigrationContext) GetGhostTableName() string {
 		tableName = this.OriginalTableName
 	}
 	if this.TimestampAllTable {
-		suffix = fmt.Sprintf("%s_gho", timeToTimestamp(this.StartTime))
+		suffix = fmt.Sprintf("%v_gho", this.StartTime.Unix())
 	} else {
 		suffix = "gho"
 	}
@@ -320,7 +320,7 @@ func (this *MigrationContext) GetOldTableName() string {
 		tableName = this.OriginalTableName
 	}
 	if this.TimestampOldTable || this.TimestampAllTable {
-		suffix = fmt.Sprintf("%s_del", timeToTimestamp(this.StartTime))
+		suffix = fmt.Sprintf("%v_del", this.StartTime.Unix())
 	} else {
 		suffix = "del"
 	}
@@ -337,7 +337,7 @@ func (this *MigrationContext) GetChangelogTableName() string {
 		tableName = this.OriginalTableName
 	}
 	if this.TimestampAllTable {
-		suffix = fmt.Sprintf("%s_ghc", timeToTimestamp(this.StartTime))
+		suffix = fmt.Sprintf("%v_ghc", this.StartTime.Unix())
 	} else {
 		suffix = "ghc"
 	}

--- a/go/base/context.go
+++ b/go/base/context.go
@@ -154,6 +154,7 @@ type MigrationContext struct {
 	InitiallyDropOldTable        bool
 	InitiallyDropGhostTable      bool
 	TimestampOldTable            bool // Should old table name include a timestamp
+	TimestampAllTable            bool // Should all table names include a timestamp
 	CutOverType                  CutOver
 	ReplicaServerId              uint
 
@@ -285,51 +286,62 @@ func NewMigrationContext() *MigrationContext {
 }
 
 func getSafeTableName(baseName string, suffix string) string {
-	name := fmt.Sprintf("_%s_%s", baseName, suffix)
+	name := fmt.Sprintf("~%s_%s", baseName, suffix)
 	if len(name) <= mysql.MaxTableNameLength {
 		return name
 	}
 	extraCharacters := len(name) - mysql.MaxTableNameLength
-	return fmt.Sprintf("_%s_%s", baseName[0:len(baseName)-extraCharacters], suffix)
+	return fmt.Sprintf("~%s_%s", baseName[0:len(baseName)-extraCharacters], suffix)
 }
 
 // GetGhostTableName generates the name of ghost table, based on original table name
 // or a given table name
 func (this *MigrationContext) GetGhostTableName() string {
-	if this.ForceTmpTableName != "" {
-		return getSafeTableName(this.ForceTmpTableName, "gho")
-	} else {
-		return getSafeTableName(this.OriginalTableName, "gho")
-	}
-}
-
-// GetOldTableName generates the name of the "old" table, into which the original table is renamed.
-func (this *MigrationContext) GetOldTableName() string {
-	var tableName string
+	var tableName, suffix string
 	if this.ForceTmpTableName != "" {
 		tableName = this.ForceTmpTableName
 	} else {
 		tableName = this.OriginalTableName
 	}
-
-	if this.TimestampOldTable {
-		t := this.StartTime
-		timestamp := fmt.Sprintf("%d%02d%02d%02d%02d%02d",
-			t.Year(), t.Month(), t.Day(),
-			t.Hour(), t.Minute(), t.Second())
-		return getSafeTableName(tableName, fmt.Sprintf("%s_del", timestamp))
+	if this.TimestampAllTable {
+		suffix = fmt.Sprintf("%s_gho", timeToTimestamp(this.StartTime))
+	} else {
+		suffix = "gho"
 	}
-	return getSafeTableName(tableName, "del")
+	return getSafeTableName(tableName, suffix)
+}
+
+// GetOldTableName generates the name of the "old" table, into which the original table is renamed.
+func (this *MigrationContext) GetOldTableName() string {
+	var tableName, suffix string
+	if this.ForceTmpTableName != "" {
+		tableName = this.ForceTmpTableName
+	} else {
+		tableName = this.OriginalTableName
+	}
+	if this.TimestampOldTable || this.TimestampAllTable {
+		suffix = fmt.Sprintf("%s_del", timeToTimestamp(this.StartTime))
+	} else {
+		suffix = "del"
+	}
+	return getSafeTableName(tableName, suffix)
 }
 
 // GetChangelogTableName generates the name of changelog table, based on original table name
 // or a given table name.
 func (this *MigrationContext) GetChangelogTableName() string {
+	var tableName, suffix string
 	if this.ForceTmpTableName != "" {
-		return getSafeTableName(this.ForceTmpTableName, "ghc")
+		tableName = this.ForceTmpTableName
 	} else {
-		return getSafeTableName(this.OriginalTableName, "ghc")
+		tableName = this.OriginalTableName
 	}
+	if this.TimestampAllTable {
+		suffix = fmt.Sprintf("%s_ghc", timeToTimestamp(this.StartTime))
+	} else {
+		suffix = "ghc"
+	}
+	return getSafeTableName(tableName, suffix)
 }
 
 // GetVoluntaryLockName returns a name of a voluntary lock to be used throughout

--- a/go/base/context_test.go
+++ b/go/base/context_test.go
@@ -47,7 +47,7 @@ func TestGetTableNames(t *testing.T) {
 		longForm := "Jan 2, 2006 at 3:04pm (MST)"
 		context.StartTime, _ = time.Parse(longForm, "Feb 3, 2013 at 7:54pm (PST)")
 		oldTableName := context.GetOldTableName()
-		test.S(t).ExpectEquals(oldTableName, "~a1234567890123456789012345678901234567890123_1359921240_del")
+		test.S(t).ExpectEquals(oldTableName, "~a12345678901234567890123456789012345678901234567_1359921240_del")
 	}
 	{
 		context := NewMigrationContext()
@@ -55,7 +55,7 @@ func TestGetTableNames(t *testing.T) {
 		context.TimestampAllTable = true
 		longForm := "Jan 2, 2006 at 3:04pm (MST)"
 		context.StartTime, _ = time.Parse(longForm, "Feb 3, 2013 at 7:54pm (PST)")
-		test.S(t).ExpectEquals(context.GetGhostTableName(), "~a1234567890123456789012345678901234567890123_1359921240_gho")
+		test.S(t).ExpectEquals(context.GetGhostTableName(), "~a12345678901234567890123456789012345678901234567_1359921240_gho")
 	}
 	{
 		context := NewMigrationContext()

--- a/go/base/context_test.go
+++ b/go/base/context_test.go
@@ -51,6 +51,14 @@ func TestGetTableNames(t *testing.T) {
 	}
 	{
 		context := NewMigrationContext()
+		context.OriginalTableName = "a123456789012345678901234567890123456789012345678901234567890123"
+		context.TimestampAllTable = true
+		longForm := "Jan 2, 2006 at 3:04pm (MST)"
+		context.StartTime, _ = time.Parse(longForm, "Feb 3, 2013 at 7:54pm (PST)")
+		test.S(t).ExpectEquals(context.GetGhostTableName(), "~a1234567890123456789012345678901234567890123_20130203195400_gho")
+	}
+	{
+		context := NewMigrationContext()
 		context.OriginalTableName = "foo_bar_baz"
 		context.ForceTmpTableName = "tmp"
 		test.S(t).ExpectEquals(context.GetOldTableName(), "~tmp_del")

--- a/go/base/context_test.go
+++ b/go/base/context_test.go
@@ -47,7 +47,7 @@ func TestGetTableNames(t *testing.T) {
 		longForm := "Jan 2, 2006 at 3:04pm (MST)"
 		context.StartTime, _ = time.Parse(longForm, "Feb 3, 2013 at 7:54pm (PST)")
 		oldTableName := context.GetOldTableName()
-		test.S(t).ExpectEquals(oldTableName, "~a1234567890123456789012345678901234567890123_20130203195400_del")
+		test.S(t).ExpectEquals(oldTableName, "~a1234567890123456789012345678901234567890123_1359921240_del")
 	}
 	{
 		context := NewMigrationContext()
@@ -55,7 +55,7 @@ func TestGetTableNames(t *testing.T) {
 		context.TimestampAllTable = true
 		longForm := "Jan 2, 2006 at 3:04pm (MST)"
 		context.StartTime, _ = time.Parse(longForm, "Feb 3, 2013 at 7:54pm (PST)")
-		test.S(t).ExpectEquals(context.GetGhostTableName(), "~a1234567890123456789012345678901234567890123_20130203195400_gho")
+		test.S(t).ExpectEquals(context.GetGhostTableName(), "~a1234567890123456789012345678901234567890123_1359921240_gho")
 	}
 	{
 		context := NewMigrationContext()

--- a/go/base/context_test.go
+++ b/go/base/context_test.go
@@ -23,22 +23,22 @@ func TestGetTableNames(t *testing.T) {
 	{
 		context := NewMigrationContext()
 		context.OriginalTableName = "some_table"
-		test.S(t).ExpectEquals(context.GetOldTableName(), "_some_table_del")
-		test.S(t).ExpectEquals(context.GetGhostTableName(), "_some_table_gho")
-		test.S(t).ExpectEquals(context.GetChangelogTableName(), "_some_table_ghc")
+		test.S(t).ExpectEquals(context.GetOldTableName(), "~some_table_del")
+		test.S(t).ExpectEquals(context.GetGhostTableName(), "~some_table_gho")
+		test.S(t).ExpectEquals(context.GetChangelogTableName(), "~some_table_ghc")
 	}
 	{
 		context := NewMigrationContext()
 		context.OriginalTableName = "a123456789012345678901234567890123456789012345678901234567890"
-		test.S(t).ExpectEquals(context.GetOldTableName(), "_a1234567890123456789012345678901234567890123456789012345678_del")
-		test.S(t).ExpectEquals(context.GetGhostTableName(), "_a1234567890123456789012345678901234567890123456789012345678_gho")
-		test.S(t).ExpectEquals(context.GetChangelogTableName(), "_a1234567890123456789012345678901234567890123456789012345678_ghc")
+		test.S(t).ExpectEquals(context.GetOldTableName(), "~a1234567890123456789012345678901234567890123456789012345678_del")
+		test.S(t).ExpectEquals(context.GetGhostTableName(), "~a1234567890123456789012345678901234567890123456789012345678_gho")
+		test.S(t).ExpectEquals(context.GetChangelogTableName(), "~a1234567890123456789012345678901234567890123456789012345678_ghc")
 	}
 	{
 		context := NewMigrationContext()
 		context.OriginalTableName = "a123456789012345678901234567890123456789012345678901234567890123"
 		oldTableName := context.GetOldTableName()
-		test.S(t).ExpectEquals(oldTableName, "_a1234567890123456789012345678901234567890123456789012345678_del")
+		test.S(t).ExpectEquals(oldTableName, "~a1234567890123456789012345678901234567890123456789012345678_del")
 	}
 	{
 		context := NewMigrationContext()
@@ -47,15 +47,15 @@ func TestGetTableNames(t *testing.T) {
 		longForm := "Jan 2, 2006 at 3:04pm (MST)"
 		context.StartTime, _ = time.Parse(longForm, "Feb 3, 2013 at 7:54pm (PST)")
 		oldTableName := context.GetOldTableName()
-		test.S(t).ExpectEquals(oldTableName, "_a1234567890123456789012345678901234567890123_20130203195400_del")
+		test.S(t).ExpectEquals(oldTableName, "~a1234567890123456789012345678901234567890123_20130203195400_del")
 	}
 	{
 		context := NewMigrationContext()
 		context.OriginalTableName = "foo_bar_baz"
 		context.ForceTmpTableName = "tmp"
-		test.S(t).ExpectEquals(context.GetOldTableName(), "_tmp_del")
-		test.S(t).ExpectEquals(context.GetGhostTableName(), "_tmp_gho")
-		test.S(t).ExpectEquals(context.GetChangelogTableName(), "_tmp_ghc")
+		test.S(t).ExpectEquals(context.GetOldTableName(), "~tmp_del")
+		test.S(t).ExpectEquals(context.GetGhostTableName(), "~tmp_gho")
+		test.S(t).ExpectEquals(context.GetChangelogTableName(), "~tmp_ghc")
 	}
 }
 

--- a/go/base/utils.go
+++ b/go/base/utils.go
@@ -21,6 +21,12 @@ var (
 	prettifyDurationRegexp = regexp.MustCompile("([.][0-9]+)")
 )
 
+func timeToTimestamp(t time.Time) string {
+	return fmt.Sprintf("%d%02d%02d%02d%02d%02d",
+		t.Year(), t.Month(), t.Day(),
+		t.Hour(), t.Minute(), t.Second())
+}
+
 func PrettifyDurationOutput(d time.Duration) string {
 	if d < time.Second {
 		return "0s"

--- a/go/base/utils.go
+++ b/go/base/utils.go
@@ -21,12 +21,6 @@ var (
 	prettifyDurationRegexp = regexp.MustCompile("([.][0-9]+)")
 )
 
-func timeToTimestamp(t time.Time) string {
-	return fmt.Sprintf("%d%02d%02d%02d%02d%02d",
-		t.Year(), t.Month(), t.Day(),
-		t.Hour(), t.Minute(), t.Second())
-}
-
 func PrettifyDurationOutput(d time.Duration) string {
 	if d < time.Second {
 		return "0s"

--- a/localtests/test.sh
+++ b/localtests/test.sh
@@ -256,7 +256,7 @@ test_all() {
   find $tests_path ! -path . -type d -mindepth 1 -maxdepth 1 | cut -d "/" -f 3 | egrep "$test_pattern" | while read test_name ; do
     test_single "$test_name"
     if [ $? -ne 0 ] ; then
-      create_statement=$(gh-ost-test-mysql-replica test -t -e "show create table ~gh_ost_test_gho \G")
+      create_statement=$(gh-ost-test-mysql-replica test -t -e "show create table `~gh_ost_test_gho` \G")
       echo "$create_statement" >> $test_logfile
       echo "+ FAIL"
       return 1

--- a/localtests/test.sh
+++ b/localtests/test.sh
@@ -151,7 +151,7 @@ test_single() {
     --assume-rbr \
     --initially-drop-old-table \
     --initially-drop-ghost-table \
-    --throttle-query='select timestampdiff(second, min(last_update), now()) < 5 from `~gh_ost_test_ghc`' \
+    --throttle-query='select timestampdiff(second, min(last_update), now()) < 5 from \\\`~gh_ost_test_ghc\\\`' \
     --throttle-flag-file=$throttle_flag_file \
     --serve-socket-file=/tmp/gh-ost.test.sock \
     --initially-drop-socket-file \
@@ -205,7 +205,7 @@ test_single() {
     return 1
   fi
 
-  gh-ost-test-mysql-replica --default-character-set=utf8mb4 test -e "show create table `~gh_ost_test_gho`\G" -ss > $ghost_structure_output_file
+  gh-ost-test-mysql-replica --default-character-set=utf8mb4 test -e "show create table \\\`~gh_ost_test_gho\\\`\G" -ss > $ghost_structure_output_file
 
   if [ -f $tests_path/$test_name/expect_table_structure ] ; then
     expected_table_structure="$(cat $tests_path/$test_name/expect_table_structure)"
@@ -219,7 +219,7 @@ test_single() {
 
   echo_dot
   gh-ost-test-mysql-replica --default-character-set=utf8mb4 test -e "select ${orig_columns} from gh_ost_test ${order_by}" -ss > $orig_content_output_file
-  gh-ost-test-mysql-replica --default-character-set=utf8mb4 test -e "select ${ghost_columns} from `~gh_ost_test_gho` ${order_by}" -ss > $ghost_content_output_file
+  gh-ost-test-mysql-replica --default-character-set=utf8mb4 test -e "select ${ghost_columns} from \\\`~gh_ost_test_gho\\\` ${order_by}" -ss > $ghost_content_output_file
   orig_checksum=$(cat $orig_content_output_file | md5sum)
   ghost_checksum=$(cat $ghost_content_output_file | md5sum)
 
@@ -256,7 +256,7 @@ test_all() {
   find $tests_path ! -path . -type d -mindepth 1 -maxdepth 1 | cut -d "/" -f 3 | egrep "$test_pattern" | while read test_name ; do
     test_single "$test_name"
     if [ $? -ne 0 ] ; then
-      create_statement=$(gh-ost-test-mysql-replica test -t -e "show create table `~gh_ost_test_gho` \G")
+      create_statement=$(gh-ost-test-mysql-replica test -t -e "show create table \\\`~gh_ost_test_gho\\\` \G")
       echo "$create_statement" >> $test_logfile
       echo "+ FAIL"
       return 1

--- a/localtests/test.sh
+++ b/localtests/test.sh
@@ -151,7 +151,7 @@ test_single() {
     --assume-rbr \
     --initially-drop-old-table \
     --initially-drop-ghost-table \
-    --throttle-query='select timestampdiff(second, min(last_update), now()) < 5 from _gh_ost_test_ghc' \
+    --throttle-query='select timestampdiff(second, min(last_update), now()) < 5 from `~gh_ost_test_ghc`' \
     --throttle-flag-file=$throttle_flag_file \
     --serve-socket-file=/tmp/gh-ost.test.sock \
     --initially-drop-socket-file \
@@ -205,7 +205,7 @@ test_single() {
     return 1
   fi
 
-  gh-ost-test-mysql-replica --default-character-set=utf8mb4 test -e "show create table _gh_ost_test_gho\G" -ss > $ghost_structure_output_file
+  gh-ost-test-mysql-replica --default-character-set=utf8mb4 test -e "show create table `~gh_ost_test_gho`\G" -ss > $ghost_structure_output_file
 
   if [ -f $tests_path/$test_name/expect_table_structure ] ; then
     expected_table_structure="$(cat $tests_path/$test_name/expect_table_structure)"
@@ -219,7 +219,7 @@ test_single() {
 
   echo_dot
   gh-ost-test-mysql-replica --default-character-set=utf8mb4 test -e "select ${orig_columns} from gh_ost_test ${order_by}" -ss > $orig_content_output_file
-  gh-ost-test-mysql-replica --default-character-set=utf8mb4 test -e "select ${ghost_columns} from _gh_ost_test_gho ${order_by}" -ss > $ghost_content_output_file
+  gh-ost-test-mysql-replica --default-character-set=utf8mb4 test -e "select ${ghost_columns} from `~gh_ost_test_gho` ${order_by}" -ss > $ghost_content_output_file
   orig_checksum=$(cat $orig_content_output_file | md5sum)
   ghost_checksum=$(cat $ghost_content_output_file | md5sum)
 

--- a/localtests/test.sh
+++ b/localtests/test.sh
@@ -205,7 +205,7 @@ test_single() {
     return 1
   fi
 
-  gh-ost-test-mysql-replica --default-character-set=utf8mb4 test -e "show create table '~gh_ost_test_gho'\G" -ss > $ghost_structure_output_file
+  gh-ost-test-mysql-replica --default-character-set=utf8mb4 test -e "show create table \`~gh_ost_test_gho\`\G" -ss > $ghost_structure_output_file
 
   if [ -f $tests_path/$test_name/expect_table_structure ] ; then
     expected_table_structure="$(cat $tests_path/$test_name/expect_table_structure)"
@@ -219,7 +219,7 @@ test_single() {
 
   echo_dot
   gh-ost-test-mysql-replica --default-character-set=utf8mb4 test -e "select ${orig_columns} from gh_ost_test ${order_by}" -ss > $orig_content_output_file
-  gh-ost-test-mysql-replica --default-character-set=utf8mb4 test -e "select ${ghost_columns} from '~gh_ost_test_gho' ${order_by}" -ss > $ghost_content_output_file
+  gh-ost-test-mysql-replica --default-character-set=utf8mb4 test -e "select ${ghost_columns} from \`~gh_ost_test_gho\` ${order_by}" -ss > $ghost_content_output_file
   orig_checksum=$(cat $orig_content_output_file | md5sum)
   ghost_checksum=$(cat $ghost_content_output_file | md5sum)
 
@@ -256,7 +256,7 @@ test_all() {
   find $tests_path ! -path . -type d -mindepth 1 -maxdepth 1 | cut -d "/" -f 3 | egrep "$test_pattern" | while read test_name ; do
     test_single "$test_name"
     if [ $? -ne 0 ] ; then
-      create_statement=$(gh-ost-test-mysql-replica test -t -e "show create table '~gh_ost_test_gho' \G")
+      create_statement=$(gh-ost-test-mysql-replica test -t -e "show create table \`~gh_ost_test_gho\` \G")
       echo "$create_statement" >> $test_logfile
       echo "+ FAIL"
       return 1

--- a/localtests/test.sh
+++ b/localtests/test.sh
@@ -256,7 +256,7 @@ test_all() {
   find $tests_path ! -path . -type d -mindepth 1 -maxdepth 1 | cut -d "/" -f 3 | egrep "$test_pattern" | while read test_name ; do
     test_single "$test_name"
     if [ $? -ne 0 ] ; then
-      create_statement=$(gh-ost-test-mysql-replica test -t -e "show create table _gh_ost_test_gho \G")
+      create_statement=$(gh-ost-test-mysql-replica test -t -e "show create table ~gh_ost_test_gho \G")
       echo "$create_statement" >> $test_logfile
       echo "+ FAIL"
       return 1

--- a/localtests/test.sh
+++ b/localtests/test.sh
@@ -151,7 +151,7 @@ test_single() {
     --assume-rbr \
     --initially-drop-old-table \
     --initially-drop-ghost-table \
-    --throttle-query='select timestampdiff(second, min(last_update), now()) < 5 from \\\`~gh_ost_test_ghc\\\`' \
+    --throttle-query='select timestampdiff(second, min(last_update), now()) < 5 from `~gh_ost_test_ghc`' \
     --throttle-flag-file=$throttle_flag_file \
     --serve-socket-file=/tmp/gh-ost.test.sock \
     --initially-drop-socket-file \
@@ -205,7 +205,7 @@ test_single() {
     return 1
   fi
 
-  gh-ost-test-mysql-replica --default-character-set=utf8mb4 test -e "show create table \\\`~gh_ost_test_gho\\\`\G" -ss > $ghost_structure_output_file
+  gh-ost-test-mysql-replica --default-character-set=utf8mb4 test -e "show create table '~gh_ost_test_gho'\G" -ss > $ghost_structure_output_file
 
   if [ -f $tests_path/$test_name/expect_table_structure ] ; then
     expected_table_structure="$(cat $tests_path/$test_name/expect_table_structure)"
@@ -219,7 +219,7 @@ test_single() {
 
   echo_dot
   gh-ost-test-mysql-replica --default-character-set=utf8mb4 test -e "select ${orig_columns} from gh_ost_test ${order_by}" -ss > $orig_content_output_file
-  gh-ost-test-mysql-replica --default-character-set=utf8mb4 test -e "select ${ghost_columns} from \\\`~gh_ost_test_gho\\\` ${order_by}" -ss > $ghost_content_output_file
+  gh-ost-test-mysql-replica --default-character-set=utf8mb4 test -e "select ${ghost_columns} from '~gh_ost_test_gho' ${order_by}" -ss > $ghost_content_output_file
   orig_checksum=$(cat $orig_content_output_file | md5sum)
   ghost_checksum=$(cat $ghost_content_output_file | md5sum)
 
@@ -256,7 +256,7 @@ test_all() {
   find $tests_path ! -path . -type d -mindepth 1 -maxdepth 1 | cut -d "/" -f 3 | egrep "$test_pattern" | while read test_name ; do
     test_single "$test_name"
     if [ $? -ne 0 ] ; then
-      create_statement=$(gh-ost-test-mysql-replica test -t -e "show create table \\\`~gh_ost_test_gho\\\` \G")
+      create_statement=$(gh-ost-test-mysql-replica test -t -e "show create table '~gh_ost_test_gho' \G")
       echo "$create_statement" >> $test_logfile
       echo "+ FAIL"
       return 1


### PR DESCRIPTION
1. Change the prefix to `~` according to https://github.com/github/gh-ost/issues/887#issuecomment-752680725.

MySQL acquires table locks in alphabetic order.

https://dev.mysql.com/doc/refman/8.0/en/metadata-locking.html

For these two tables: `_table_gho` and `table`, MySQL first acquires `_table_gho` and then `table`, which may cause data loss.

If we change the prefix to ~, their order would be `table` and then `~table_gho`, thus solving the issue.

2. Add a `TimestampAllTable` option. If this is on, gh-ost will name tables like `~table_20220628122213_gho`




Close BYT-784 BYT-798