### PR TITLE
Tear down streamer properly

### DIFF
--- a/go/logic/streamer.go
+++ b/go/logic/streamer.go
@@ -219,5 +219,7 @@ func (this *EventsStreamer) Close() (err error) {
 }
 
 func (this *EventsStreamer) Teardown() {
+	this.migrationContext.Log.Debugf("Tearing down...")
 	this.db.Close()
+	this.Close()
 }

--- a/go/logic/streamer.go
+++ b/go/logic/streamer.go
@@ -180,6 +180,7 @@ func (this *EventsStreamer) StreamEvents(canStopStreaming func() bool) error {
 	var successiveFailures int64
 	var lastAppliedRowsEventHint mysql.BinlogCoordinates
 	for {
+		this.migrationContext.Log.Debugf("Am I gonna stop??, %v", canStopStreaming())
 		if canStopStreaming() {
 			return nil
 		}

--- a/go/logic/streamer.go
+++ b/go/logic/streamer.go
@@ -180,7 +180,6 @@ func (this *EventsStreamer) StreamEvents(canStopStreaming func() bool) error {
 	var successiveFailures int64
 	var lastAppliedRowsEventHint mysql.BinlogCoordinates
 	for {
-		this.migrationContext.Log.Debugf("Am I gonna stop??, %v", canStopStreaming())
 		if canStopStreaming() {
 			return nil
 		}

--- a/go/logic/streamer.go
+++ b/go/logic/streamer.go
@@ -10,6 +10,7 @@ import (
 	"fmt"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/github/gh-ost/go/base"
@@ -222,4 +223,5 @@ func (this *EventsStreamer) Teardown() {
 	this.migrationContext.Log.Debugf("Tearing down...")
 	this.db.Close()
 	this.Close()
+	atomic.StoreInt64(&this.migrationContext.CutOverCompleteFlag, 1)
 }


### PR DESCRIPTION
Close EventStreamer.

Set `CutOverCompleteFlag` to 1, or the following lines will loop forever
https://github.com/bytebase/gh-ost/blob/51944d977111c2b129c381c6bb5881e80ef4e94a/go/logic/streamer.go#L181-L189