### PR TITLE
fix: time.Tick resource leak

### DIFF
--- a/go/logic/applier.go
+++ b/go/logic/applier.go
@@ -344,8 +344,9 @@ func (this *Applier) InitiateHeartbeat() {
 	}
 	injectHeartbeat()
 
-	heartbeatTick := time.Tick(time.Duration(this.migrationContext.HeartbeatIntervalMilliseconds) * time.Millisecond)
-	for range heartbeatTick {
+	heartbeatTick := time.NewTicker(time.Duration(this.migrationContext.HeartbeatIntervalMilliseconds) * time.Millisecond)
+	defer heartbeatTick.Stop()
+	for range heartbeatTick.C {
 		if atomic.LoadInt64(&this.finishedMigrating) > 0 {
 			return
 		}

--- a/go/logic/migrator.go
+++ b/go/logic/migrator.go
@@ -796,8 +796,9 @@ func (this *Migrator) initiateInspector() (err error) {
 // initiateStatus sets and activates the printStatus() ticker
 func (this *Migrator) initiateStatus() error {
 	this.printStatus(ForcePrintStatusAndHintRule)
-	statusTick := time.Tick(1 * time.Second)
-	for range statusTick {
+	statusTick := time.NewTicker(1 * time.Second)
+	defer statusTick.Stop()
+	for range statusTick.C {
 		if atomic.LoadInt64(&this.finishedMigrating) > 0 {
 			return nil
 		}
@@ -1036,8 +1037,9 @@ func (this *Migrator) initiateStreaming() error {
 	}()
 
 	go func() {
-		ticker := time.Tick(1 * time.Second)
-		for range ticker {
+		ticker := time.NewTicker(1 * time.Second)
+		defer ticker.Stop()
+		for range ticker.C {
 			if atomic.LoadInt64(&this.finishedMigrating) > 0 {
 				return
 			}


### PR DESCRIPTION
Use instead
```go
tick := time.NewTicker(duration)
defer tick.Stop()
```
According to https://github.com/golang/go/issues/11662, time.Tick causes a resource leak.
If using gh-ost as a binary, time.Tick might be fine because these go routines live nearly as long as gh-ost (note that they return on finishedMigrating). The OS would collect the resources after gh-ost binary exits.
But we are using gh-ost as a library within bytebase, which is a long-running process, so we should collect these resources on our own.