### PR TITLE
feat: tries to gracefully shut down gh-ost on PanicAbort

### DIFF
--- a/go/logic/applier.go
+++ b/go/logic/applier.go
@@ -160,7 +160,7 @@ func (this *Applier) ValidateOrDropExistingTables() error {
 		}
 	}
 	if len(this.migrationContext.GetOldTableName()) > mysql.MaxTableNameLength {
-		this.migrationContext.Log.Fatalf("--timestamp-old-table defined, but resulting table name (%s) is too long (only %d characters allowed)", this.migrationContext.GetOldTableName(), mysql.MaxTableNameLength)
+		return fmt.Errorf("--timestamp-old-table defined, but resulting table name (%s) is too long (only %d characters allowed)", this.migrationContext.GetOldTableName(), mysql.MaxTableNameLength)
 	}
 
 	if this.tableExists(this.migrationContext.GetOldTableName()) {

--- a/go/logic/migrator.go
+++ b/go/logic/migrator.go
@@ -257,11 +257,10 @@ func (this *Migrator) onChangelogHeartbeatEvent(dmlEvent *binlog.BinlogDMLEvent)
 	}
 }
 
-// listenOnPanicAbort aborts on abort request
+// listenOnPanicAbort tries to gracefully shutdown gh-ost on abort request
 func (this *Migrator) listenOnPanicAbort() {
 	err := <-this.migrationContext.PanicAbort
 	this.migrationContext.Log.Errore(err)
-
 	this.teardown()
 }
 

--- a/go/logic/streamer.go
+++ b/go/logic/streamer.go
@@ -170,7 +170,6 @@ func (this *EventsStreamer) readCurrentBinlogCoordinates() error {
 // executed by a goroutine
 func (this *EventsStreamer) StreamEvents(canStopStreaming func() bool) error {
 	go func() {
-		//TODO(xz): close eventsChannel done
 		for binlogEntry := range this.eventsChannel {
 			if binlogEntry.DmlEvent != nil {
 				this.notifyListeners(binlogEntry.DmlEvent)

--- a/go/logic/streamer.go
+++ b/go/logic/streamer.go
@@ -170,6 +170,7 @@ func (this *EventsStreamer) readCurrentBinlogCoordinates() error {
 // executed by a goroutine
 func (this *EventsStreamer) StreamEvents(canStopStreaming func() bool) error {
 	go func() {
+		//TODO(xz): close eventsChannel done
 		for binlogEntry := range this.eventsChannel {
 			if binlogEntry.DmlEvent != nil {
 				this.notifyListeners(binlogEntry.DmlEvent)
@@ -181,10 +182,12 @@ func (this *EventsStreamer) StreamEvents(canStopStreaming func() bool) error {
 	var lastAppliedRowsEventHint mysql.BinlogCoordinates
 	for {
 		if canStopStreaming() {
+			close(this.eventsChannel)
 			return nil
 		}
 		if err := this.binlogReader.StreamEvents(canStopStreaming, this.eventsChannel); err != nil {
 			if canStopStreaming() {
+				close(this.eventsChannel)
 				return nil
 			}
 

--- a/go/logic/throttler.go
+++ b/go/logic/throttler.go
@@ -167,7 +167,6 @@ func (this *Throttler) collectReplicationLag(firstThrottlingCollected chan<- boo
 		if atomic.LoadInt64(&this.finishedMigrating) > 0 {
 			return
 		}
-		//TODO(xz): safe
 		go collectFunc()
 	}
 }
@@ -214,7 +213,6 @@ func (this *Throttler) collectControlReplicasLag() {
 			connectionConfig.Key = replicaKey
 
 			lagResult := &mysql.ReplicationLagResult{Key: connectionConfig.Key}
-			//TODO(xz): safe
 			go func() {
 				lagResult.Lag, lagResult.Err = readReplicaLag(connectionConfig)
 				lagResults <- lagResult
@@ -356,7 +354,6 @@ func (this *Throttler) collectGeneralThrottleMetrics() error {
 		hibernateUntilTime := time.Now().Add(hibernateDuration)
 		atomic.StoreInt64(&this.migrationContext.HibernateUntil, hibernateUntilTime.UnixNano())
 		this.migrationContext.Log.Errorf("critical-load met: %s=%d, >=%d. Will hibernate for the duration of %+v, until %+v", variableName, value, threshold, hibernateDuration, hibernateUntilTime)
-		//TODO(xz): safe
 		go func() {
 			time.Sleep(hibernateDuration)
 			this.migrationContext.SetThrottleGeneralCheckResult(base.NewThrottleCheckResult(true, "leaving hibernation", base.LeavingHibernationThrottleReasonHint))
@@ -370,7 +367,6 @@ func (this *Throttler) collectGeneralThrottleMetrics() error {
 	}
 	if criticalLoadMet && this.migrationContext.CriticalLoadIntervalMilliseconds > 0 {
 		this.migrationContext.Log.Errorf("critical-load met once: %s=%d, >=%d. Will check again in %d millis", variableName, value, threshold, this.migrationContext.CriticalLoadIntervalMilliseconds)
-		//TODO(xz): safe
 		go func() {
 			timer := time.NewTimer(time.Millisecond * time.Duration(this.migrationContext.CriticalLoadIntervalMilliseconds))
 			<-timer.C
@@ -422,12 +418,10 @@ func (this *Throttler) collectGeneralThrottleMetrics() error {
 // that may affect throttling. There are several components, all running independently,
 // that collect such metrics.
 func (this *Throttler) initiateThrottlerCollection(firstThrottlingCollected chan<- bool) {
-	//TODO(xz): all 3 are safe
 	go this.collectReplicationLag(firstThrottlingCollected)
 	go this.collectControlReplicasLag()
 	go this.collectThrottleHTTPStatus(firstThrottlingCollected)
 
-	//TODO(xz): safe
 	go func() {
 		this.collectGeneralThrottleMetrics()
 		firstThrottlingCollected <- true
@@ -465,7 +459,6 @@ func (this *Throttler) initiateThrottlerChecks() error {
 		this.migrationContext.SetThrottled(shouldThrottle, throttleReason, throttleReasonHint)
 	}
 	throttlerFunction()
-	//TODO(xz): safe
 	for range throttlerTick.C {
 		if atomic.LoadInt64(&this.finishedMigrating) > 0 {
 			return nil


### PR DESCRIPTION
Bytebase uses gh-ost as a library. `Log.Fatal` will kill the whole process, `Log.Panic` could be recovered but it's a hassle to implement that due to the nested go routines.
However, after some investigation, we find that `Fatal` or `Panic` may not be necessary after all.

In this PR, we try to gracefully shut down gh-ost, and make sure that go routines exit as many as possible.
The go routines in server.go are left to another day.

Close BYT-826.