### PR TITLE
fix: divide by zero panic

### DIFF
--- a/go/logic/migrator.go
+++ b/go/logic/migrator.go
@@ -1012,7 +1012,7 @@ func (this *Migrator) printStatus(rule PrintStatusRule, writers ...io.Writer) {
 	w := io.MultiWriter(writers...)
 	fmt.Fprintln(w, status)
 
-	if elapsedSeconds%this.migrationContext.HooksStatusIntervalSec == 0 {
+	if this.migrationContext.HooksStatusIntervalSec > 0 && elapsedSeconds%this.migrationContext.HooksStatusIntervalSec == 0 {
 		this.hooksExecutor.onStatus(status)
 	}
 }


### PR DESCRIPTION
`HooksStatusIntervalSec` could be 0, which will cause an integer divided by zero panic.