### PR TITLE
feat: add an indicator for successful migrations

### DIFF
--- a/go/base/context.go
+++ b/go/base/context.go
@@ -208,6 +208,7 @@ type MigrationContext struct {
 	CutOverCompleteFlag                    int64
 	InCutOverCriticalSectionFlag           int64
 	PanicAbort                             chan error
+	MigrationSuccessFlag                   int64
 
 	OriginalTableColumnsOnApplier    *sql.ColumnList
 	OriginalTableColumns             *sql.ColumnList

--- a/go/logic/migrator.go
+++ b/go/logic/migrator.go
@@ -449,6 +449,7 @@ func (this *Migrator) Migrate() (err error) {
 	if err := this.hooksExecutor.onSuccess(); err != nil {
 		return err
 	}
+	atomic.StoreInt64(&this.migrationContext.MigrationSuccessFlag, 1)
 	this.migrationContext.Log.Infof("Done migrating %s.%s", sql.EscapeName(this.migrationContext.DatabaseName), sql.EscapeName(this.migrationContext.OriginalTableName))
 	return nil
 }


### PR DESCRIPTION
Set the flag if the migration is successful.

We need this because we need to know if a migration succeeds to update the migration history accordingly after we've moved the logic to gh-ost cutover task in https://github.com/bytebase/bytebase/pull/1985.