### PR TITLE
fix: "Tear down streamer properly (#3)" refined

### DIFF
--- a/go/logic/migrator.go
+++ b/go/logic/migrator.go
@@ -200,7 +200,7 @@ func (this *Migrator) consumeRowCopyComplete() {
 }
 
 func (this *Migrator) canStopStreaming() bool {
-	return atomic.LoadInt64(&this.migrationContext.CutOverCompleteFlag) != 0
+	return atomic.LoadInt64(&this.migrationContext.CutOverCompleteFlag) != 0 || atomic.LoadInt64(&this.finishedMigrating) > 0
 }
 
 // onChangelogEvent is called when a binlog event operation on the changelog table is intercepted.

--- a/go/logic/streamer.go
+++ b/go/logic/streamer.go
@@ -218,5 +218,7 @@ func (this *EventsStreamer) Close() (err error) {
 }
 
 func (this *EventsStreamer) Teardown() {
+	this.migrationContext.Log.Debugf("Tearing down...")
 	this.db.Close()
+	this.Close()
 }

--- a/go/logic/streamer.go
+++ b/go/logic/streamer.go
@@ -10,7 +10,6 @@ import (
 	"fmt"
 	"strings"
 	"sync"
-	"sync/atomic"
 	"time"
 
 	"github.com/github/gh-ost/go/base"
@@ -219,8 +218,5 @@ func (this *EventsStreamer) Close() (err error) {
 }
 
 func (this *EventsStreamer) Teardown() {
-	this.migrationContext.Log.Debugf("Tearing down...")
 	this.db.Close()
-	this.Close()
-	atomic.StoreInt64(&this.migrationContext.CutOverCompleteFlag, 1)
 }


### PR DESCRIPTION
Use the existing `finishedMigrating` flag here to judge is better here. Set `CutOverCompleteFlag` for the sake of tearing down is a bit abusive.