### PR TITLE
fix: test.sh

### DIFF
--- a/localtests/test.sh
+++ b/localtests/test.sh
@@ -163,6 +163,7 @@ test_single() {
     --stack \
     --execute ${extra_args[@]}"
   echo_dot
+  echo $cmd
   echo $cmd > $exec_command_file
   echo_dot
   bash $exec_command_file 1> $test_logfile 2>&1

--- a/localtests/test.sh
+++ b/localtests/test.sh
@@ -151,7 +151,7 @@ test_single() {
     --assume-rbr \
     --initially-drop-old-table \
     --initially-drop-ghost-table \
-    --throttle-query='select timestampdiff(second, min(last_update), now()) < 5 from `~gh_ost_test_ghc`' \
+    --throttle-query='select timestampdiff(second, min(last_update), now()) < 5 from \`~gh_ost_test_ghc\`' \
     --throttle-flag-file=$throttle_flag_file \
     --serve-socket-file=/tmp/gh-ost.test.sock \
     --initially-drop-socket-file \

--- a/localtests/test.sh
+++ b/localtests/test.sh
@@ -163,7 +163,6 @@ test_single() {
     --stack \
     --execute ${extra_args[@]}"
   echo_dot
-  echo $cmd
   echo $cmd > $exec_command_file
   echo_dot
   bash $exec_command_file 1> $test_logfile 2>&1


### PR DESCRIPTION
Shell scripting is hard.

before
```
+ pass
./localtests/test.sh: line 164: ~gh_ost_test_ghc: command not found
Testing: unsigned-rename....bin/gh-ost --user=gh-ost --*** --host=127.0.0.1 --port=19227 --assume-master-host=127.0.0.1:19226 --database=test --table=gh_ost_test --alter='engine=innodb' --exact-rowcount --assume-rbr --initially-drop-old-table --initially-drop-ghost-table --throttle-query='select timestampdiff(second, min(last_update), now()) < 5 from ' --throttle-flag-file=/tmp/gh-ost-test.ghost.throttle.flag --serve-socket-file=/tmp/gh-ost.test.sock --initially-drop-socket-file --test-on-replica --default-retries=3 --chunk-size=10 --verbose --debug --stack --execute --alter="change column iu iu_renamed int unsigned not null" --approve-renamed-columns
```
after
```
+ pass
Testing: compound-pk....bin/gh-ost --user=gh-ost --*** --host=127.0.0.1 --port=19227 --assume-master-host=127.0.0.1:19226 --database=test --table=gh_ost_test --alter='engine=innodb' --exact-rowcount --assume-rbr --initially-drop-old-table --initially-drop-ghost-table --throttle-query='select timestampdiff(second, min(last_update), now()) < 5 from `~gh_ost_test_ghc`' --throttle-flag-file=/tmp/gh-ost-test.ghost.throttle.flag --serve-socket-file=/tmp/gh-ost.test.sock --initially-drop-socket-file --test-on-replica --default-retries=3 --chunk-size=10 --verbose --debug --stack --execute
```