### PR TITLE
fix: unusual usepassword:true error

### DIFF
--- a/itest.sh
+++ b/itest.sh
@@ -5,7 +5,6 @@ primary_port=
 replica_port=
 tps=
 rate=
-ncore=$(nproc)
 
 # first run benchmark to find out max transactions per second.
 # use 50% of the max tps to simulate workload.
@@ -43,7 +42,6 @@ test_once_oltp_insert() {
         --mysql-user=ghost \
         --mysql-password=ghost \
         --mysql-db=db \
-        --threads=$ncore \
         --table-size=$table_size oltp_insert prepare
 
     tps=$(
@@ -53,7 +51,6 @@ test_once_oltp_insert() {
             --mysql-user=ghost \
             --mysql-password=ghost \
             --mysql-db=db \
-            --threads=$ncore \
             --table-size=$table_size --time=10 \
             oltp_insert run | grep -o 'transactions:.*)' | cut -d '(' -f 2 | cut -d ' ' -f 1
     )
@@ -69,7 +66,6 @@ test_once_oltp_insert() {
         --table-size=$table_size \
         --time=10000 \
         --rate=$rate \
-        --threads=$ncore \
         --report-interval=10 \
         oltp_insert run &
 
@@ -127,7 +123,6 @@ test_once_tpcc() {
         --mysql-user=ghost \
         --mysql-password=ghost \
         --mysql-db=db \
-        --threads=$ncore \
         --use-fk=0 \
         --scale=1
 
@@ -138,7 +133,6 @@ test_once_tpcc() {
             --mysql-user=ghost \
             --mysql-password=ghost \
             --mysql-db=db \
-            --threads=$ncore \
             --time=10 \
             --scale=1 |
             grep -o 'transactions:.*)' | cut -d '(' -f 2 | cut -d ' ' -f 1
@@ -152,7 +146,6 @@ test_once_tpcc() {
         --mysql-user=ghost \
         --mysql-password=ghost \
         --mysql-db=db \
-        --threads=$ncore \
         --time=10000 \
         --rate=$rate \
         --report-interval=10 \

--- a/itest.sh
+++ b/itest.sh
@@ -5,6 +5,7 @@ primary_port=
 replica_port=
 tps=
 rate=
+ncore=$(nproc)
 
 # first run benchmark to find out max transactions per second.
 # use 50% of the max tps to simulate workload.
@@ -42,6 +43,7 @@ test_once_oltp_insert() {
         --mysql-user=ghost \
         --mysql-password=ghost \
         --mysql-db=db \
+        --threads=$ncore \
         --table-size=$table_size oltp_insert prepare
 
     tps=$(
@@ -51,6 +53,7 @@ test_once_oltp_insert() {
             --mysql-user=ghost \
             --mysql-password=ghost \
             --mysql-db=db \
+            --threads=$ncore \
             --table-size=$table_size --time=10 \
             oltp_insert run | grep -o 'transactions:.*)' | cut -d '(' -f 2 | cut -d ' ' -f 1
     )
@@ -66,6 +69,7 @@ test_once_oltp_insert() {
         --table-size=$table_size \
         --time=10000 \
         --rate=$rate \
+        --threads=$ncore \
         --report-interval=10 \
         oltp_insert run &
 
@@ -123,6 +127,7 @@ test_once_tpcc() {
         --mysql-user=ghost \
         --mysql-password=ghost \
         --mysql-db=db \
+        --threads=$ncore \
         --use-fk=0 \
         --scale=1
 
@@ -133,6 +138,7 @@ test_once_tpcc() {
             --mysql-user=ghost \
             --mysql-password=ghost \
             --mysql-db=db \
+            --threads=$ncore \
             --time=10 \
             --scale=1 |
             grep -o 'transactions:.*)' | cut -d '(' -f 2 | cut -d ' ' -f 1
@@ -146,6 +152,7 @@ test_once_tpcc() {
         --mysql-user=ghost \
         --mysql-password=ghost \
         --mysql-db=db \
+        --threads=$ncore \
         --time=10000 \
         --rate=$rate \
         --report-interval=10 \

--- a/itest.sh
+++ b/itest.sh
@@ -35,7 +35,6 @@ test_once_oltp_insert() {
     ghostest-primary -uroot -e"DROP DATABASE IF EXISTS db; CREATE DATABASE db;"
 
     primary_port=$(ghostest-primary -uroot -e "select @@port" -ss)
-    replica_port=$(ghostest-replica -uroot -e "select @@port" -ss)
 
     sysbench \
         --mysql-host='127.0.0.1' \
@@ -69,6 +68,8 @@ test_once_oltp_insert() {
         --rate=$rate \
         --report-interval=10 \
         oltp_insert run &
+
+    replica_port=$(ghostest-replica -uroot -e "select @@port" -ss)
 
     gh-ost \
         --execute \
@@ -116,7 +117,6 @@ test_once_tpcc() {
     ghostest-primary -uroot -e"DROP DATABASE IF EXISTS db; CREATE DATABASE db;"
 
     primary_port=$(ghostest-primary -uroot -e "select @@port" -ss)
-    replica_port=$(ghostest-replica -uroot -e "select @@port" -ss)
 
     /tpcc.lua prepare --mysql-host='127.0.0.1' \
         --mysql-port="$primary_port" \
@@ -150,6 +150,8 @@ test_once_tpcc() {
         --rate=$rate \
         --report-interval=10 \
         &
+
+    replica_port=$(ghostest-replica -uroot -e "select @@port" -ss)
 
     gh-ost \
         --execute \


### PR DESCRIPTION
```
    primary_port=$(ghostest-primary -uroot -e "select @@port" -ss)
    replica_port=$(ghostest-replica -uroot -e "select @@port" -ss)
```

Putting these two lines side by side causes a strange error.